### PR TITLE
Implement login use case and module

### DIFF
--- a/src/data/models/LoginResponse.ts
+++ b/src/data/models/LoginResponse.ts
@@ -1,0 +1,7 @@
+export interface LoginResponse {
+  token: string
+  user: {
+    id: string
+    name: string
+  }
+}

--- a/src/data/models/index.ts
+++ b/src/data/models/index.ts
@@ -1,0 +1,1 @@
+export * from './LoginResponse'

--- a/src/data/usecase/login.ts
+++ b/src/data/usecase/login.ts
@@ -1,0 +1,20 @@
+import type { Credentials, LoginUseCase } from '../../domain/usecase'
+import type { LoginResponse } from '../models'
+
+export class RemoteLoginUseCase implements LoginUseCase {
+  constructor(private readonly url: string) {}
+
+  async execute(credentials: Credentials): Promise<LoginResponse> {
+    const response = await fetch(this.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(credentials)
+    })
+
+    if (!response.ok) {
+      throw new Error('Login failed')
+    }
+
+    return response.json() as Promise<LoginResponse>
+  }
+}

--- a/src/domain/usecase/index.ts
+++ b/src/domain/usecase/index.ts
@@ -1,0 +1,1 @@
+export * from './login'

--- a/src/domain/usecase/login.ts
+++ b/src/domain/usecase/login.ts
@@ -1,0 +1,10 @@
+import type { LoginResponse } from '../../data/models'
+
+export interface Credentials {
+  email: string
+  password: string
+}
+
+export interface LoginUseCase {
+  execute(credentials: Credentials): Promise<LoginResponse>
+}

--- a/src/main/factories/modules/login/index.ts
+++ b/src/main/factories/modules/login/index.ts
@@ -1,0 +1,4 @@
+import { makeLogin } from '../../usecase/makeLogin'
+import { Login } from '../../../../presentation/modules/login'
+
+export const makeLoginModule = () => <Login loginUseCase={makeLogin()} />

--- a/src/main/factories/usecase/makeLogin.ts
+++ b/src/main/factories/usecase/makeLogin.ts
@@ -1,0 +1,6 @@
+import { RemoteLoginUseCase } from '../../data/usecase/login'
+
+export const makeLogin = () => {
+  const url = '/api/login'
+  return new RemoteLoginUseCase(url)
+}

--- a/src/presentation/modules/login/Login.tsx
+++ b/src/presentation/modules/login/Login.tsx
@@ -1,0 +1,30 @@
+import { Button, Form, Input } from 'antd'
+import type { Credentials, LoginUseCase } from '../../../domain/usecase'
+
+type Props = {
+  loginUseCase: LoginUseCase
+}
+
+const Login = ({ loginUseCase }: Props) => {
+  const [form] = Form.useForm<Credentials>()
+
+  const onFinish = async (values: Credentials) => {
+    await loginUseCase.execute(values)
+  }
+
+  return (
+    <Form form={form} onFinish={onFinish} layout="vertical">
+      <Form.Item name="email" label="Email" rules={[{ required: true, type: 'email' }]}> 
+        <Input placeholder="Email" />
+      </Form.Item>
+      <Form.Item name="password" label="Password" rules={[{ required: true }]}> 
+        <Input.Password placeholder="Password" />
+      </Form.Item>
+      <Form.Item>
+        <Button type="primary" htmlType="submit">Login</Button>
+      </Form.Item>
+    </Form>
+  )
+}
+
+export default Login

--- a/src/presentation/modules/login/index.tsx
+++ b/src/presentation/modules/login/index.tsx
@@ -1,0 +1,1 @@
+export { default as Login } from './Login'


### PR DESCRIPTION
## Summary
- add LoginResponse model and re-export
- define LoginUseCase interface
- implement RemoteLoginUseCase
- create factories for login use case and module
- build login form with Ant Design and export module

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68423aa28284832e85c48c09716b5c39